### PR TITLE
update package/cloudant/index for use with ghost 0.6.4

### DIFF
--- a/files/core/server/storage/cloudant.js
+++ b/files/core/server/storage/cloudant.js
@@ -7,7 +7,7 @@ var _       = require('lodash'),
     nodefn  = require('when/node/function'),
     path    = require('path'),
     when    = require('when'),
-    errors  = require('../errorHandling'),
+    errors  = require('../errors'),
     config  = require('../config'),
     baseStore   = require('./base'),
     https =  require('https'),
@@ -103,7 +103,7 @@ cloudantFileStore = _.extend(baseStore, {
     // - returns a promise which ultimately returns the full url to the uploaded image
     'save': function (image) {
         var saved = when.defer(),
-            targetDir = this.getTargetDir(config().paths.imagesPath),
+            targetDir = this.getTargetDir(config.get().paths.imagesPath),
             targetFilename;
 
         this.getUniqueFileName(this, image, targetDir).then(function (filename) {
@@ -116,7 +116,7 @@ cloudantFileStore = _.extend(baseStore, {
         }).then(function () {
             // The src for the image must be in URI format, not a file system path, which in Windows uses \
             // For local file system storage can use relative path so add a slash
-            var fullUrl = (config().paths.subdir + '/' + path.relative(config().paths.appRoot, targetFilename)).replace(new RegExp('\\' + path.sep, 'g'), '/');
+            var fullUrl = (config.get().paths.subdir + '/' + path.relative(config.get().paths.appRoot, targetFilename)).replace(new RegExp('\\' + path.sep, 'g'), '/');
 
             // Let's assume PNG images are the norm and toggle the content-type from there
             var contentType = 'image/png';
@@ -216,7 +216,7 @@ cloudantFileStore = _.extend(baseStore, {
         var extension = path.extname(filename);
         var base = path.basename(filename, extension);
         var fullname = base + extension;
-        var fullUrl = (config().paths.subdir + '/' + path.relative(config().paths.appRoot, filename)).replace(new RegExp('\\' + path.sep, 'g'), '/');
+        var fullUrl = (config.get().paths.subdir + '/' + path.relative(config.get().paths.appRoot, filename)).replace(new RegExp('\\' + path.sep, 'g'), '/');
 
         // Let's try to get this image from Cloudant by checking for the doc first
         imagestore.get(base, {revs_info: true}, function(err, getBody) {
@@ -252,7 +252,7 @@ cloudantFileStore = _.extend(baseStore, {
             ONE_YEAR_MS = 365 * 24 * ONE_HOUR_MS;
 
         // For some reason send divides the max age number by 1000
-        return express['static'](config().paths.imagesPath, {maxAge: ONE_YEAR_MS});
+        return express.static(config.get().paths.imagesPath, {maxAge: ONE_YEAR_MS});
     }
 });
 

--- a/files/core/server/storage/index.js
+++ b/files/core/server/storage/index.js
@@ -1,7 +1,7 @@
-var errors = require('../errorHandling'),
+var errors = require('../errors'),
     storage;
 
-function get_storage() {
+function getStorage() {
     // TODO: this is where the check for storage apps should go
     // Local file system is the default
     var storageChoice = 'cloudant';
@@ -19,4 +19,4 @@ function get_storage() {
     return storage;
 }
 
-module.exports.get_storage = get_storage;
+module.exports.getStorage = getStorage;

--- a/files/package.json
+++ b/files/package.json
@@ -1,93 +1,113 @@
 {
-    "name"        : "ghost",
-    "version"     : "0.4.2",
-    "description" : "Just a blogging platform.",
-    "author"      : "Ghost Foundation",
-    "homepage"    : "http://ghost.org",
-    "keywords"    : [
-        "ghost",
-        "blog",
-        "cms"
-    ],
-    "repository"  : {
-        "type": "git",
-        "url": "git://github.com/TryGhost/Ghost.git"
-    },
-    "bugs"        : "https://github.com/TryGhost/Ghost/issues",
-    "contributors": "https://github.com/TryGhost/Ghost/graphs/contributors",
-    "licenses"    : [
-        {
-            "type": "MIT",
-            "url": "https://raw.github.com/TryGhost/Ghost/master/LICENSE"
-        }
-    ],
-    "main": "./core/index",
-    "scripts": {
-        "start": "node index --production",
-        "test": "./node_modules/.bin/grunt validate --verbose"
-    },
-    "engines": {
-        "node": "~0.10.0"
-    },
-    "engineStrict": true,
-    "dependencies": {
-        "bcryptjs": "0.7.10",
-        "bookshelf": "0.6.1",
-        "busboy": "0.0.12",
-        "colors": "0.6.2",
-        "connect-slashes": "1.2.0",
-        "downsize": "0.0.5",
-        "express": "3.4.6",
-        "express-hbs": "0.7.9",
-        "fs-extra": "0.8.1",
-        "knex": "0.5.8",
-        "lodash": "2.4.1",
-        "moment": "2.4.0",
-        "nano" : "5.7.1",
-        "node-polyglot": "0.3.0",
-        "node-uuid": "1.4.1",
-        "nodemailer": "0.5.13",
-        "js-yaml" : "3.0.2", 
-        "rss": "0.2.1",
-        "semver": "2.2.1",
-        "showdown": "https://github.com/ErisDS/showdown/archive/v0.3.2-ghost.tar.gz",
-        "socket.io" : "*",
-        "ansi-to-html" : "0.1.1",
-        "underscore": "1.5.2",
-        "unidecode": "0.1.3",
-        "validator": "3.4.0",
-        "when": "2.7.0",
-        "xml": "0.0.12"
-    },
-    "optionalDependencies": {
-        "mysql": "2.1.1"
-    },
-    "devDependencies": {
-        "blanket": "~1.1.5",
-        "bower": "~1.2.8",
-        "grunt": "~0.4.1",
-        "grunt-cli": "~0.1.13",
-        "grunt-contrib-clean": "~0.5.0",
-        "grunt-contrib-compress": "~0.5.2",
-        "grunt-contrib-concat": "~0.3.0",
-        "grunt-contrib-copy": "~0.4.1",
-        "grunt-contrib-handlebars": "~0.6.0",
-        "grunt-contrib-jshint": "~0.8.0",
-        "grunt-contrib-uglify": "~0.2.5",
-        "grunt-contrib-watch": "~0.5.3",
-        "grunt-express-server": "~0.4.11",
-        "grunt-groc": "~0.4.0",
-        "grunt-mocha-cli": "~1.4.0",
-        "grunt-shell": "~0.6.1",
-        "grunt-update-submodules": "~0.2.1",
-        "matchdep": "~0.3.0",
-        "mocha": "~1.15.1",
-        "nock": "0.27.2",
-        "rewire": "~2.0.0",
-        "request": "~2.29.0",
-        "require-dir": "~0.1.0",
-        "should": "~2.1.1",
-        "sinon": "~1.7.3",
-        "supertest": "~0.8.2"
+  "name": "ghost",
+  "version": "0.6.4",
+  "description": "Just a blogging platform.",
+  "author": "Ghost Foundation",
+  "homepage": "http://ghost.org",
+  "keywords": [
+    "ghost",
+    "blog",
+    "cms"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/TryGhost/Ghost.git"
+  },
+  "bugs": "https://github.com/TryGhost/Ghost/issues",
+  "contributors": "https://github.com/TryGhost/Ghost/graphs/contributors",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://raw.github.com/TryGhost/Ghost/master/LICENSE"
     }
+  ],
+  "main": "./core/index",
+  "scripts": {
+    "start": "node index --production",
+    "test": "grunt validate --verbose"
+  },
+  "engines": {
+    "node": "~0.10.0 || ~0.12.0",
+    "iojs": "~1.2.0"
+  },
+  "dependencies": {
+    "ansi-to-html": "^0.3.0",
+    "bcryptjs": "2.1.0",
+    "bluebird": "2.9.25",
+    "body-parser": "1.10.0",
+    "bookshelf": "0.7.9",
+    "busboy": "0.2.9",
+    "chalk": "1.0.0",
+    "cheerio": "0.18.0",
+    "compression": "1.2.2",
+    "connect-slashes": "1.3.0",
+    "cookie-session": "1.1.0",
+    "downsize": "0.0.8",
+    "express": "4.12.3",
+    "express-hbs": "0.8.4",
+    "extract-zip": "1.0.3",
+    "fs-extra": "0.13.0",
+    "glob": "4.3.2",
+    "html-to-text": "1.3.0",
+    "js-yaml": "^3.3.1",
+    "knex": "0.7.3",
+    "lodash": "2.4.1",
+    "moment": "2.10.2",
+    "morgan": "1.5.0",
+    "nano": "^6.1.4",
+    "node-polyglot": "^0.4.3",
+    "node-uuid": "1.4.2",
+    "nodemailer": "0.7.1",
+    "oauth2orize": "1.0.1",
+    "passport": "0.2.1",
+    "passport-http-bearer": "1.0.1",
+    "passport-oauth2-client-password": "0.1.2",
+    "path-match": "1.2.2",
+    "request": "2.55.0",
+    "rss": "1.1.1",
+    "semver": "4.3.3",
+    "showdown": "^1.2.1",
+    "showdown-ghost": "0.3.6",
+    "socket.io": "^1.3.6",
+    "sqlite3": "3.0.8",
+    "underscore": "^1.8.3",
+    "unidecode": "0.1.3",
+    "validator": "3.39.0",
+    "when": "^3.7.3",
+    "xml": "1.0.0"
+  },
+  "optionalDependencies": {
+    "mysql": "2.1.1",
+    "pg": "4.1.1"
+  },
+  "devDependencies": {
+    "blanket": "~1.1.5",
+    "bower": "~1.3.10",
+    "grunt": "~0.4.5",
+    "grunt-bg-shell": "^2.3.1",
+    "grunt-cli": "~0.1.13",
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-compress": "~0.11.0",
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-copy": "~0.5.0",
+    "grunt-contrib-jshint": "~0.11.2",
+    "grunt-contrib-uglify": "~0.6.0",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-docker": "~0.0.8",
+    "grunt-express-server": "~0.4.19",
+    "grunt-jscs": "~1.8.0",
+    "grunt-mocha-cli": "~1.13.0",
+    "grunt-mocha-istanbul": "2.4.0",
+    "grunt-shell": "~1.1.1",
+    "grunt-update-submodules": "~0.4.1",
+    "matchdep": "~0.3.0",
+    "nock": "0.52.4",
+    "require-dir": "~0.1.0",
+    "rewire": "~2.1.0",
+    "should": "~6.0.1",
+    "sinon": "~1.12.2",
+    "supertest": "~0.15.0",
+    "testem": "^0.6.23",
+    "top-gh-contribs": "^1.0.0"
+  }
 }


### PR DESCRIPTION
For compatibility with ghost 0.6.4 using Bluemix w/ Cloudant, the following changes need to be made:
  - update dependencies in package.json
  - update references to `../errors` from `../errorHandling`
  - config is now referenced as `config.get()` instead of `config()`
  - `get_storage()` has been renamed to `getStorage()`