### PR TITLE
Utilize prototypal inheritance in cloudant filestorage

### DIFF
--- a/files/core/server/storage/index.js
+++ b/files/core/server/storage/index.js
@@ -2,9 +2,8 @@ var errors = require('../errors'),
     storage;
 
 function getStorage() {
-    // TODO: this is where the check for storage apps should go
-    // Local file system is the default
     var storageChoice = 'cloudant';
+    var StorageConstructor;
 
     if (storage) {
         return storage;
@@ -12,10 +11,11 @@ function getStorage() {
 
     try {
         // TODO: determine if storage has all the necessary methods
-        storage = require('./' + storageChoice);
+        StorageConstructor = require('./' + storageChoice);
     } catch (e) {
         errors.logError(e);
     }
+    storage = new StorageConstructor();
     return storage;
 }
 


### PR DESCRIPTION
This abstraction is being tracked in ghost via https://github.com/TryGhost/Ghost/issues/2852
Specifically, see this commit: https://github.com/TryGhost/Ghost/commit/66845def852d87a6cce9582b7684d234ce81d74b

This PR updates our cloudant filestorage to follow the same inheritance model that Ghost changed to

Githubs comparison tool makes this change look a lot more dramatic than it actually is! None of the contents of each method has changed, it just changes the format from:

``` js
var cloudantFileStore = _.extend(baseStore, {
    methodName: function (arg1, arg2) {...}
});
module.exports = cloudantFileStore;
```

To:

``` js
function CloudantFileStore() {
}
util.inherits(CloudantFileStore, baseStore);

CloudantFileStore.prototype.methodName = function (arg1, arg2) {...};

module.exports = CloudantFileStore;
```

Each method does exactly the same thing!
